### PR TITLE
Strict typing, py.typed and link issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,3 +54,9 @@ extlinks = {
 extensions += ['sphinx.ext.extlinks']
 
 # local
+
+# jaraco/jaraco.test#8
+nitpick_ignore += [
+    ('py:class', '_pytest.config.Config'),
+    ('py:class', '_pytest.nodes.Item'),
+]

--- a/jaraco/test/__init__.py
+++ b/jaraco/test/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
 
-def property_error(name):
+def property_error(name: str) -> str:
     """
     Generate a regular expression for capturing the expected
     error messages that can result from attempting to set

--- a/jaraco/test/cpython.py
+++ b/jaraco/test/cpython.py
@@ -10,11 +10,11 @@ Python versions (for compatibility with Python 3.9 and earlier).
 import importlib
 import types
 
-from jaraco.context import suppress
 from jaraco.collections import Projection
+from jaraco.context import suppress
 
 
-def from_test_support(*names):
+def from_test_support(*names: str) -> types.SimpleNamespace:
     """
     Return a SimpleNamespace of names from test.support.
 
@@ -28,7 +28,7 @@ def from_test_support(*names):
 
 
 @suppress(ImportError)
-def try_import(name):
+def try_import(name: str) -> types.ModuleType:
     """
     Attempt to import a submodule of test.support; return None if missing.
     """

--- a/jaraco/test/http.py
+++ b/jaraco/test/http.py
@@ -1,39 +1,41 @@
 import urllib.request
 
 import pytest
+
 import jaraco.functools
 from jaraco.context import ExceptionTrap
 
 
 @jaraco.functools.once
-def has_internet():
+def has_internet() -> bool:
     """
     Is this host able to reach the Internet?
 
     Return True if the internet appears reachable and False
     otherwise.
     """
-    with ExceptionTrap() as trap:
+    with ExceptionTrap() as trap:  # type: ignore[no-untyped-call] # jaraco/jaraco.context#15
         urllib.request.urlopen('http://pypi.org')
     return not trap
 
 
-def check_internet():
+def check_internet() -> None:
     """
     (pytest) Skip if internet is unavailable.
     """
-    has_internet() or pytest.skip('Internet connectivity unavailable')
+    if not has_internet():
+        pytest.skip('Internet connectivity unavailable')
 
 
 @pytest.fixture
-def needs_internet():
+def needs_internet() -> None:
     """
     Pytest fixture signaling that internet is required.
     """
     check_internet()
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     """
     Register the 'network' marker.
     """
@@ -42,9 +44,9 @@ def pytest_configure(config):
     )
 
 
-def pytest_runtest_setup(item):
+def pytest_runtest_setup(item: pytest.Item) -> None:
     """
     For any tests marked with 'network', install fixture.
     """
     for marker in item.iter_markers(name='network'):
-        item.fixturenames.extend({'needs_internet'} - set(item.fixturenames))
+        item.fixturenames.extend({'needs_internet'} - set(item.fixturenames))  # type: ignore[attr-defined]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 # Is the project well-typed?
-strict = False
+strict = True
 
 # Early opt-in even when strict = False
 warn_unused_ignores = True
@@ -13,3 +13,8 @@ explicit_package_bases = True
 disable_error_code =
 	# Disable due to many false positives
 	overload-overlap,
+
+# Can't ignore inline because the error is inconsistent
+# Exists but untyped on Python 3.8 on Windows. Doesn't exist anywhere else.
+[mypy-test.*]
+ignore_missing_imports = True

--- a/newsfragments/8.feature.rst
+++ b/newsfragments/8.feature.rst
@@ -1,0 +1,1 @@
+Complete annotations and add ``py.typed`` marker -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,3 @@ pytest11 = {"jaraco.test.http" = "jaraco.test.http"}
 
 
 [tool.setuptools_scm]
-
-
-[tool.pytest-enabler.mypy]
-# Disabled due to jaraco/skeleton#143

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -3,7 +3,8 @@ import urllib.request
 import pytest
 
 
-def test_needs_internet(needs_internet):
+@pytest.mark.usefixtures("needs_internet")
+def test_needs_internet() -> None:
     """
     This test should always succeed or be skipped.
     """
@@ -11,7 +12,7 @@ def test_needs_internet(needs_internet):
 
 
 @pytest.mark.network
-def test_network_marker():
+def test_network_marker() -> None:
     """
     This test should always succeed or be skipped.
     """


### PR DESCRIPTION
Ref: https://github.com/jaraco/skeleton/issues/143
Closes https://github.com/jaraco/jaraco.test/issues/7
Works towards https://github.com/pypa/setuptools/issues/2345

Upstream issues:
- https://github.com/jaraco/jaraco.context/issues/15

Another one that could reasonably use strict type-checking immediately.