### PR TITLE
Add `__future__.annotations`

### DIFF
--- a/jaraco/test/__init__.py
+++ b/jaraco/test/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 

--- a/jaraco/test/cpython.py
+++ b/jaraco/test/cpython.py
@@ -6,6 +6,7 @@ Python versions (for compatibility with Python 3.9 and earlier).
 >>> os_helper.temp_dir
 <function temp_dir at ...>
 """
+from __future__ import annotations
 
 import importlib
 import types

--- a/jaraco/test/cpython.py
+++ b/jaraco/test/cpython.py
@@ -6,6 +6,7 @@ Python versions (for compatibility with Python 3.9 and earlier).
 >>> os_helper.temp_dir
 <function temp_dir at ...>
 """
+
 from __future__ import annotations
 
 import importlib

--- a/jaraco/test/http.py
+++ b/jaraco/test/http.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import urllib.request
 
 import pytest

--- a/newsfragments/10.bugfix.rst
+++ b/newsfragments/10.bugfix.rst
@@ -1,0 +1,1 @@
+Added `__future__.annotations`.

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import urllib.request
 
 import pytest


### PR DESCRIPTION
When packaging for EPEL9, I've encountered an issue where `pytest` is a bit too old and it fails at import time because it couldn't find `pytest.Config`. The class is still there in `6.2.2` with appropriate interface, but it is not exposed in `pytest`, just in `_pytest`. Adding `__future__.annotations` should at least help unblock these issues.